### PR TITLE
Generate table.go during build

### DIFF
--- a/unidecode.go
+++ b/unidecode.go
@@ -3,6 +3,8 @@
 // approximations.
 package unidecode
 
+//go:generate go run make_table.go
+
 import (
 	"sync"
 	"unicode"


### PR DESCRIPTION
This patch is already applied in the Debian packaging, I am forwarding it to you :)

It is good practice not to commit binary contents inside git.

go:generate was created for this.
